### PR TITLE
Added support for PCL

### DIFF
--- a/src/JsonParser.PCL/JsonParser.PCL.csproj
+++ b/src/JsonParser.PCL/JsonParser.PCL.csproj
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{8452C491-AAF3-485C-8248-798F7581A9BC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>JsonParser.PCL</RootNamespace>
+    <AssemblyName>JsonParser.PCL</AssemblyName>
+    <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;PCL</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <DefineConstants>PCL</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="..\JsonParser\JsonParser.cs">
+      <Link>JsonParser.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+</Project>

--- a/src/JsonParser.PCL/Properties/AssemblyInfo.cs
+++ b/src/JsonParser.PCL/Properties/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+[assembly: AssemblyTitle("Dimebrain JSON Parser")]
+[assembly: AssemblyDescription("A parser for the JSON specification.")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Dimebrain")]
+[assembly: AssemblyProduct("JsonParser")]
+[assembly: AssemblyCopyright("Public Domain")]
+[assembly: AssemblyTrademark("Public Domain")]
+[assembly: AssemblyCulture("")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: InternalsVisibleTo("JsonParser.Tests")]

--- a/src/JsonParser/JsonParser.cs
+++ b/src/JsonParser/JsonParser.cs
@@ -238,13 +238,13 @@ namespace Json
                     var time = new DateTime(1970, 1, 1).ToUniversalTime();
                     value = time.AddSeconds(seconds);
                 }
-				 
+
                 if (info.PropertyType == typeof(byte[]))
                 {
                     var bytes = (List<object>)value;
                     value = bytes.Select(symbol => Convert.ToByte(symbol)).ToArray();
                 }
-				
+
                 if (info.PropertyType == typeof(double))
                 {
                     value = Convert.ToDouble(value);
@@ -375,9 +375,13 @@ namespace Json
                 return;
             }
 
+            #if PCL
+            var properties = item.GetRuntimeProperties().ToArray();
+            #else
             var properties = item.GetProperties(
                 BindingFlags.Public | BindingFlags.Instance
                 );
+            #endif
 
             _cache.Add(item, properties);
         }
@@ -494,9 +498,8 @@ namespace Json
             sb.Append("\"");
             var symbols = item.ToString().ToCharArray();
             
-            var unicodes = symbols
-				.Select(symbol => (int)symbol)
-				.Select(symbol => GetUnicode(symbol));
+            var unicodes = symbols.Select(symbol => GetUnicode(symbol));
+
             foreach (var unicode in unicodes)
             {
                 sb.Append(unicode);

--- a/src/JsonParser/JsonParser.cs
+++ b/src/JsonParser/JsonParser.cs
@@ -238,13 +238,13 @@ namespace Json
                     var time = new DateTime(1970, 1, 1).ToUniversalTime();
                     value = time.AddSeconds(seconds);
                 }
-
+				 
                 if (info.PropertyType == typeof(byte[]))
                 {
                     var bytes = (List<object>)value;
-                    value = bytes.Select(Convert.ToByte).ToArray();
+                    value = bytes.Select(symbol => Convert.ToByte(symbol)).ToArray();
                 }
-
+				
                 if (info.PropertyType == typeof(double))
                 {
                     value = Convert.ToDouble(value);
@@ -494,7 +494,9 @@ namespace Json
             sb.Append("\"");
             var symbols = item.ToString().ToCharArray();
             
-            var unicodes = symbols.Select(symbol => (int)symbol).Select(GetUnicode);
+            var unicodes = symbols
+				.Select(symbol => (int)symbol)
+				.Select(symbol => GetUnicode(symbol));
             foreach (var unicode in unicodes)
             {
                 sb.Append(unicode);
@@ -943,4 +945,3 @@ namespace Json
     }
 #endif
 }
-


### PR DESCRIPTION
Added support for [PCL](https://msdn.microsoft.com/en-us/library/vstudio/gg597391%28v=vs.100%29.aspx)

For whatever reason, Microsoft decided to [remove the `Type.GetProperties()` method](https://msdn.microsoft.com/en-us/library/windows/apps/br230302%28v=VS.85%29.aspx#reflection) for Metro.
