### PR TITLE
Correct handling of escaped characters in string values

### DIFF
--- a/src/JsonParser.Tests/JsonParserTests.cs
+++ b/src/JsonParser.Tests/JsonParserTests.cs
@@ -51,6 +51,18 @@ namespace Json.Tests
         }
 
         [Test]
+        public void Can_parse_strings_with_escaped_characters()
+        {
+            const string json = @"{""string"":""\""\/\\\b\f\n\r\t""}";
+
+            var bag = JsonParser.FromJson(json);
+            Assert.IsNotNull(bag);
+            Assert.AreEqual(1, bag.Count);
+            Assert.True(bag.ContainsKey("string"));
+            Assert.AreEqual("\"/\\\b\f\n\r\t", bag["string"]);
+        }
+
+        [Test]
         public void Can_parse_arrays()
         {
             const string json = @"[{""color"": ""red"",""value"": ""#f00""}]";
@@ -93,10 +105,10 @@ namespace Json.Tests
         }
 
 		[Test]
-		public void Can_serialize_with_string_with_quotas()
+		public void Can_serialize_strings_with_characters_to_escape()
 		{
-			const string expected = @"{""name"":""Ba\""r""}";
-			var dog = new Dog { Name = "Ba\"r" };			
+			const string expected = @"{""name"":""Ba\""\/\\\b\f\n\r\tr""}";
+			var dog = new Dog { Name = "Ba\"/\\\b\f\n\r\tr" };			
 			var actual = JsonParser.Serialize(dog);
 			Assert.AreEqual(expected, actual);
 		}
@@ -198,26 +210,6 @@ namespace Json.Tests
         {
             public string Value { get; set; }
         }
-
-        [Test]
-        public void Can_ignore_solidus_in_string_literals()
-        {
-            const string expected = @"What is the phone #/digits?";
-
-            var serialized = JsonParser.Serialize(
-                new StringWrapper
-                    {
-                        Value = @"What is the phone #\/digits?"
-                    }
-                );
-
-            Console.WriteLine(serialized);
-
-            var actual = JsonParser.Deserialize<StringWrapper>(serialized);
-            
-            Assert.AreEqual(expected, actual.Value);
-        }
-
 
         public class DogArray
         {

--- a/src/JsonParser/JsonParser.cs
+++ b/src/JsonParser/JsonParser.cs
@@ -508,14 +508,26 @@ namespace Json
             sb.Append("\"");
         }
 
-        internal static string GetUnicode(int code)
+        internal static string GetUnicode(char character)
         {
             // http://unicode.org/roadmaps/bmp/
+            switch (character)
+            {
+                case '"': return @"\""";
+                case '/': return @"\/";
+                case '\\': return @"\\";
+                case '\b': return @"\b";
+                case '\f': return @"\f";
+                case '\n': return @"\n";
+                case '\r': return @"\r";
+                case '\t': return @"\t";
+            }
+
+            var code = (int)character;
             var basicLatin = code >= 32 && code <= 126;
             if (basicLatin)
             {
-                var value = (char)code;
-                return value == '"' ? @"\""" : new string(value, 1);
+                return new string(character, 1);
             }
 
             var unicode = BaseConvert(code, _base16, 4);
@@ -578,14 +590,24 @@ namespace Json
                         switch (symbol)
                         {
                             case '/':
+                            case '\\':
+                            case '"':
                                 sb.Append(symbol);
                                 break;
-                            case '\\':
                             case 'b':
+                                sb.Append('\b');
+                                break;
                             case 'f':
+                                sb.Append('\f');
+                                break;
                             case 'n':
+                                sb.Append('\n');
+                                break;
                             case 'r':
+                                sb.Append('\r');
+                                break;
                             case 't':
+                                sb.Append('\t');
                                 break;
                             case 'u': // Unicode literals
                                 if (index < data.Count - 5)


### PR DESCRIPTION
This library is nice to use, thanks.

However, I have found that it does not conform to the JSON spec regarding handling escaped characters in string values. Particularly, I could not parse JSON serialized with this lib by JsonCpp. I have tried a couple of other JSON parsers with no success, just to test. The reason was one of the string contained backslashes which were not properly escaped when serialized to JSON.

I have modified serialization/parsing behavior for string values according to a spec of string value found at [json.org](http://www.json.org/).

I removed test **Can_ignore_solidus_in_string_literals** because it did not conform to the spec above. It was confusing anyway: why string should change (lose backslash) when serialized and then parsed back?