### PR TITLE
Converting JsonObject to static types

### DIFF
--- a/src/JsonParser.Tests/Json.Tests.csproj
+++ b/src/JsonParser.Tests/Json.Tests.csproj
@@ -83,6 +83,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="JsonObjectTests.cs" />
     <Compile Include="JsonParserTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/JsonParser.Tests/JsonObjectTests.cs
+++ b/src/JsonParser.Tests/JsonObjectTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+
+namespace Json.Tests
+{
+#if NET40
+    [TestFixture]
+    public class JsonObjectTests
+    {
+        private class Person
+        {
+            public string Name { get; set; }
+            public int Age { get; set; }
+        }
+
+
+        [Test]
+        public void Can_convert_to_type()
+        {
+            var bag = JsonParser.InitializeBag();
+            bag["name"] = "Bob";
+            bag["age"] = 21;
+
+            var jsonObject = new JsonObject(bag);
+            var person1 = jsonObject.Convert<Person>();
+            var person2 = jsonObject.Convert(typeof(Person)) as Person;
+            dynamic jsonObject3 = jsonObject;
+            var person3 = (Person)jsonObject3;
+
+            Assert.IsNotNull(person1);
+            Assert.AreEqual("Bob", person1.Name);
+            Assert.AreEqual(21, person1.Age);
+            Assert.IsNotNull(person2);
+            Assert.AreEqual("Bob", person2.Name);
+            Assert.AreEqual(21, person2.Age);
+            Assert.IsNotNull(person3);
+            Assert.AreEqual("Bob", person3.Name);
+            Assert.AreEqual(21, person3.Age);
+        }
+    }
+#endif
+}


### PR DESCRIPTION
This may be useful when type for some part of JSON content is not known in advance. They can be represented with **IDictionary<string, object>** properties and converted to a static type when it is known.

    class Command
    {
        string Name { get; set; }
        IDictionary<string, object> Arguments { get; set; }
        public T ConvertArguments<T>()
        {
            return new JsonObject(Arguments).Convert<T>();
        }
    }

    ...
    var command = JsonParser.Deserialize<Command>(jsonStr);
    switch (command.Name)
    {
        case "start": 
            ExecStartCommand(command.ConvertArguments<StartArguments>());
            break;
        case "stop": 
            ExecStopCommand(command.ConvertArguments<StopArguments>());
            break;
    }

Also, consider making public the new overloads of **Deserialize** method (with **bag** parameter) to eliminate the need of intermediate **JsonObject** and to support such scenarios in .NET 3.5.